### PR TITLE
Version 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Luau Changelog
 
+## 1.0.3 (1 August 2020)
+
+### Fixed
+
+1. Fixed incorrect partial word highlighting
+2. Fixed numbers with underscore separators directly followed by a comma/semicolon not being highlighted
+
 ## 1.0.2 (25 July 2020)
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "icon": "icon.png",
     "displayName": "Luau",
     "description": "Support for Roblox's Luau language.",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "publisher": "UnderMyWheel",
     "license": "MIT",
     "homepage": "https://github.com/UnderMyWheel/vscode-luau",

--- a/syntaxes/luau.tmLanguage.json
+++ b/syntaxes/luau.tmLanguage.json
@@ -3,7 +3,7 @@
 	"patterns": [
 		{
 			"name": "keyword.luau",
-			"match": "\\b(workspace|game|script|shared|ipairs|next|pairs|_G|_VERSION|utf8\\.(charpattern))|math\\.(huge|pi)\\b"
+			"match": "\\b(workspace|game|script|shared|ipairs|next|pairs|_G|_VERSION|utf8\\.(charpattern)|math\\.(huge|pi))\\b"
 		},
 		{
 			"name": "support.class.luau",
@@ -19,7 +19,7 @@
 		},
 		{
 			"name": "constant.numeric.luau",
-			"match": "(?<!\\S)(?!$)[-+]?(\\d*|\\d+(?:_\\d+)*)(?:\\.\\d+)?(?!\\S)\\b"
+			"match": "((?<!\\S)|(?<=[,;]))(?!$)[-+]?(\\d*|\\d+(?:_\\d+)*)(?:.\\d+)?((?!\\S)|(?=[,;]))"
 		},
 		{
 			"captures": {

--- a/tests/API.lua
+++ b/tests/API.lua
@@ -27,6 +27,7 @@ Vector3int16
 
 and
 break
+continue
 do
 else
 elseif
@@ -218,10 +219,10 @@ end
 -5
 +5
 -.5
+525,242
+5_000,2_500
 
 --- All below should NOT be included ---
-
-5,242
 242_
 5_
 _


### PR DESCRIPTION
1. Fixed incorrect partial word highlighting
2. Fixed numbers with underscore separators directly followed by a comma/semicolon not being highlighted