### PR TITLE
"get service" snippet sets local variable

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -104,7 +104,7 @@
 
     "get service": {
         "prefix": "getser",
-        "body": "game:GetService(\"${1|AssetService,BadgeService,ChangeHistoryService,CollectionService,ContextActionService,DataStoreService,GamepadService,GamePassService,GroupService,GuiService,HapticService,HttpService,InsertService,JointsService,LocalizationService,LogService,MarketplaceService,MessagingService,PathfindingService,PhysicsService,PluginGuiService,PolicyService,RunService,ServerScriptService,SocialService,SoundService,StudioService,TeleportService,TestService,TextService,TweenService,UserInputService,VRService,Workspace|}\")",
+        "body": "local $1 = game:GetService(\"${1|AssetService,BadgeService,ChangeHistoryService,CollectionService,ContextActionService,DataStoreService,GamepadService,GamePassService,GroupService,GuiService,HapticService,HttpService,InsertService,JointsService,LocalizationService,LogService,MarketplaceService,MessagingService,PathfindingService,PhysicsService,PluginGuiService,PolicyService,RunService,ServerScriptService,SocialService,SoundService,StudioService,TeleportService,TestService,TextService,TweenService,UserInputService,VRService,Workspace|}\")",
         "description": "Returns a service with the class name requested."
     },
 


### PR DESCRIPTION
According to the [Roblox Lua Style guide](https://roblox.github.io/lua-style-guide/):

> All services should be referenced using `game:GetService` at the top of the file.

As such, it makes sense to use this snippet at the beginning of a file, then access the service somewhere else in the file. It is annoying to have to type a variable of the same name, almost eliminating all the time saved by the snippet. This PR modifies the snippet to also set the variable name:

```
game:GetService("ReplicatedStorage")
```

...now becomes...

```
local ReplicatedStorage = game:GetService("ReplicatedStorage")
```

It may be more appropriate to create an entirely separate snippet for this, but I don't see much point in an inline call to `GetService`, and it also seems like its against the style guide recommendations.